### PR TITLE
Removed Items without relevant data

### DIFF
--- a/app/components/comparison/components/comparison.component.ts
+++ b/app/components/comparison/components/comparison.component.ts
@@ -102,4 +102,11 @@ export class ComparisonComponent {
         }
         this.change();
     }
+
+    public changeDisplayAll() {
+        if (this.confServ.comparison) {
+            this.confServ.comparison.displayall = !this.confServ.comparison.displayall;
+        }
+        this.change();
+    }
 }

--- a/app/components/comparison/shared/components/comparison.ts
+++ b/app/components/comparison/shared/components/comparison.ts
@@ -8,6 +8,7 @@ export class Comparison {
     public repository: string;
     public details: Details;
     public displaytemplate: boolean;
+    public displayall: boolean;
 
     constructor(jsonObj: any) {
         this.title = jsonObj.title ? jsonObj.title : "Ultimate-Comparison";
@@ -17,6 +18,7 @@ export class Comparison {
         this.repository = jsonObj.repository ? jsonObj.repository : "https://github.com/ultimate-comparisons/ultimate-comparison-BASE.git";
         this.details = jsonObj.details ? new Details(jsonObj.details) : new Details({});
         this.displaytemplate = jsonObj.displaytemplate ? jsonObj.displaytemplate : false;
+        this.displayall = jsonObj.displayall ? jsonObj.displayall : false;
     }
 
 }

--- a/app/components/comparison/templates/comparison.template.html
+++ b/app/components/comparison/templates/comparison.template.html
@@ -88,6 +88,10 @@
                     <pcheckbox [checked]="confServ.comparison.displaytemplate" (checkedChange)="changeDisplayTemplate()"
                                [label]="'Display Template'"></pcheckbox>
                 </pitem>
+                <pitem>
+                    <pcheckbox [checked]="confServ.comparison.displayall" (checkedChange)="changeDisplayAll()"
+                               [label]="'Show Uncompared'"></pcheckbox>
+                </pitem>
                 <h6>Latex</h6>
                 <pitem>
                     <pbutton (click)="downloadLatexTable()">Download Table</pbutton>

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -16,7 +16,7 @@
     </thead>
     <tbody>
     <template ngFor let-dat [ngForOf]="data | orderBy: [order,orderOption] | datafilter: [query, displayTemplate]">
-        <tr>
+        <tr *ngIf="shouldBeShown(dat)">
             <template ngFor let-column [ngForOf]="columns | tablefilter">
                 <td *ngIf="column.type?.tag==='url'"><a href="{{dat.getProperty(column.url).text}}" target="_blank">{{dat.getProperty(column.tag).text}}</a>
                 </td>

--- a/app/components/output/generic-table/generic-table.component.ts
+++ b/app/components/output/generic-table/generic-table.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter, ApplicationRef, ChangeDetectionStrategy } from "@angular/core";
 import { TableData, Data, CriteriaSelection } from "./../../comparison/shared/index";
 import { ComparisonCitationService } from "./../../comparison/components/comparison-citation.service";
+import { ComparisonConfigService } from "../../comparison/components/comparison-config.service";
 
 @Component({
     selector: 'generictable',
@@ -31,7 +32,8 @@ export class GenericTableComponent {
 
     private ctrlCounter: number = 0;
 
-    constructor(private ar: ApplicationRef) {
+    constructor(private ar: ApplicationRef,
+                private confServ: ComparisonConfigService) {
     }
 
     private orderClick(e: MouseEvent, value: string) {
@@ -64,5 +66,21 @@ export class GenericTableComponent {
             this.orderOption[this.ctrlCounter] = 1;
         }
         return this.order.findIndex(val => val == value) >= 0 && this.orderOption[this.order.findIndex(val => val == value)] == option;
+    }
+
+    public shouldBeShown(data: Data) {
+        if (this.confServ.comparison && this.confServ.comparison.displayall) {
+            return true;
+        }
+        let val = true;
+        for (let column of this.confServ.tableDataSet.getTableDataArray()) {
+            if (column.display && data.properties[column.tag] != null && data.properties[column.tag].plain != "") {
+                return true;
+            }
+            if (column.display && data.properties[column.tag] != null) {
+                val = false;
+            }
+        }
+        return val;
     }
 }


### PR DESCRIPTION
If an item does not have any data in a shown column (besides description and name), it is not shown.
Name and Short Description are ignored for this analysis.
There is also a checkbox with the label Show Uncompared which shows every item.

Issue: #28
Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>

Screenshots:
1. Element missing some data, but still has other shown data
![selection_004](https://cloud.githubusercontent.com/assets/7841099/24449421/808f3b40-1477-11e7-9039-6e23e1e30fe6.png)
2. Element missing because it does not have any shown data
![selection_005](https://cloud.githubusercontent.com/assets/7841099/24449451/92298504-1477-11e7-8531-9e83ae8cdd25.png)
3. Show Uncompared is checked
![selection_006](https://cloud.githubusercontent.com/assets/7841099/24449480/a53c13aa-1477-11e7-9614-0bf3176e4b50.png)
4. All elements are shown, when only description and name are checked
![selection_007](https://cloud.githubusercontent.com/assets/7841099/24449511/bf84b2e4-1477-11e7-8ed6-ab323b628e1c.png)
5. Checkbox Show Uncompared
![selection_008](https://cloud.githubusercontent.com/assets/7841099/24449568/ecfb3eb4-1477-11e7-944a-27702ab250a6.png)



