### PR TITLE
sorted references and removed double numbers

### DIFF
--- a/app/components/comparison/components/comparison-citation.service.ts
+++ b/app/components/comparison/components/comparison-citation.service.ts
@@ -15,6 +15,19 @@ export class ComparisonCitationService {
     constructor(private http: Http) {
     }
 
+    public sortedReferences() : any[] {
+        let values: any[] = [];
+        for (let reference of this.references) {
+            let key: any = reference;
+            let entry: any = {"html": this.bibEntriesHtml[key]};
+            entry["index"] = this.bibEntriesInline[key];
+            entry["index"] = entry["index"].substr(1, entry["index"].length - 2);
+            values.push(entry)
+        }
+        console.log(values);
+        return values.sort((a, b) => a.index - b.index);
+    }
+
     public loadCitationData(cd: ChangeDetectorRef) {
         this.http.request('citation/output/fbib.json')
             .subscribe(res => {

--- a/app/components/output/references-table/references-table.component.html
+++ b/app/components/output/references-table/references-table.component.html
@@ -1,10 +1,10 @@
 <table>
-    <template ngFor let-entry [ngForOf]="this.citationServ.references">
+    <template ngFor let-entry [ngForOf]="this.citationServ.sortedReferences()">
         <tr style="padding-left:5px;">
             <td style="padding-right:10px;font-size:small;padding-top:3px;width:15%;" valign="top">
-                {{citationServ.bibEntriesInline[entry]}}:
+                {{'[' + entry.index + ']'}}:
             </td>
-            <td [id]=entry [innerHtml]="citationServ.bibEntriesHtml[entry]|sanitizeHtml"></td>
+            <td [id]=entry [innerHtml]="entry.html|sanitizeHtml"></td>
         </tr>
     </template>
 </table>

--- a/app/components/pipes/sanitizer-pipe/sanitizer.pipe.ts
+++ b/app/components/pipes/sanitizer-pipe/sanitizer.pipe.ts
@@ -11,6 +11,10 @@ export class SanitizerPipe implements PipeTransform {
     }
 
     transform(v: string): SafeHtml {
-        return this._sanitizer.bypassSecurityTrustHtml(v);
+        let html = this._sanitizer.bypassSecurityTrustHtml(v);
+        if (html.hasOwnProperty("changingThisBreaksApplicationSecurity") && html["changingThisBreaksApplicationSecurity"].startsWith("<p>")) {
+            html["changingThisBreaksApplicationSecurity"] = "<p>" + html["changingThisBreaksApplicationSecurity"].substr(html["changingThisBreaksApplicationSecurity"].indexOf('.') + 1);
+        }
+        return html;
     }
 } 

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -6,3 +6,7 @@ html {
 .cite-link {
     color: lightgrey;
 }
+
+li a.cite-link {
+    color: #337ab7;
+}


### PR DESCRIPTION
fixes #15

references are sorted by the displayed reference number.
also references are numbered only once, the number in the format \d+\. was removed and \[\d+\] was kept.

New display
![image](https://cloud.githubusercontent.com/assets/7841099/25073879/19ec04f4-22f0-11e7-90f7-e313c7d92fdf.png)

Also fixes a problem with links.
The links at the top of the page were also lightgrey, this is fixed.

Previously: 
![image](https://cloud.githubusercontent.com/assets/7841099/25073889/7414f1ac-22f0-11e7-851a-8f63ea472b1b.png)

Now:
![image](https://cloud.githubusercontent.com/assets/7841099/25073894/83e08c36-22f0-11e7-9221-017e910af5f4.png)


