### PR TITLE
Added auto coloring and support for direct color

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ This is an ultimate comparison framework written in angular2.
   {
     "name": "slow",
     "description": "Overall performance above 200ms",
-    "class": "label-danger"
+    "class": "label-danger",
+    "color": "red"
   }
   ```
   - The label with the value "slow" has the tooltip "overall performance above 200ms", and will be red ("label-danger")
+  - You can choose between red and class, classes are the preferred way. If both are missing, an automatic color is assigned.
 
   ![table.json](https://cdn.rawgit.com/ultimate-comparisons/ultimate-comparison-BASE/master/media/table.svg) 
 3. The file `comparison-configuration/criteria.json` defines filter criterias for the table data.

--- a/app/components/comparison/components/comparison-citation.service.ts
+++ b/app/components/comparison/components/comparison-citation.service.ts
@@ -24,7 +24,6 @@ export class ComparisonCitationService {
             entry["index"] = entry["index"].substr(1, entry["index"].length - 2);
             values.push(entry)
         }
-        console.log(values);
         return values.sort((a, b) => a.index - b.index);
     }
 

--- a/app/components/comparison/shared/components/color-dictionary.ts
+++ b/app/components/comparison/shared/components/color-dictionary.ts
@@ -1,6 +1,3 @@
-/**
- * Created by armin on 25.04.17.
- */
 export class ColorDictionary {
     private colorDict: {[label: string]: string} = {};
 

--- a/app/components/comparison/shared/components/color-dictionary.ts
+++ b/app/components/comparison/shared/components/color-dictionary.ts
@@ -1,0 +1,18 @@
+/**
+ * Created by armin on 25.04.17.
+ */
+export class ColorDictionary {
+    private colorDict: {[label: string]: string} = {};
+
+    public pushColor(label: string, color: string) {
+        this.colorDict[label] = color;
+    }
+
+    public getColor(label: string): string {
+        if (this.colorDict[label]) {
+            return this.colorDict[label];
+        } else {
+            return "";
+        }
+    }
+}

--- a/app/components/comparison/shared/components/color-dictionary.ts
+++ b/app/components/comparison/shared/components/color-dictionary.ts
@@ -1,7 +1,7 @@
 export class ColorDictionary {
     private colorDict: {[label: string]: string} = {};
 
-    public pushColor(label: string, color: string) {
+    public setColor(label: string, color: string) {
         this.colorDict[label] = color;
     }
 

--- a/app/components/comparison/shared/components/table-data.set.ts
+++ b/app/components/comparison/shared/components/table-data.set.ts
@@ -1,4 +1,5 @@
 import { TableData, LabelCls, Value, Type } from "../index";
+import { ColorDictionary } from "./color-dictionary";
 
 export class TableDataSet {
     private tableDataSet: {[name: string]: TableData;} = {}
@@ -35,10 +36,19 @@ export class TableDataSet {
                     }
                 })
             }
+            let colors: ColorDictionary = new ColorDictionary();
+            if (obj.type && obj.type.values) {
+                for (const v of obj.type.values) {
+                    if (v.color) {
+                        colors.pushColor(v.name, v.color);
+                    }
+                }
+            }
             let type: Type = new Type(
                 obj.type.tag,
                 obj.type.class,
-                lcls
+                lcls,
+                colors
             )
             let td: TableData = new TableData(
                 obj.name,

--- a/app/components/comparison/shared/components/table-data.set.ts
+++ b/app/components/comparison/shared/components/table-data.set.ts
@@ -40,7 +40,7 @@ export class TableDataSet {
             if (obj.type && obj.type.values) {
                 for (const v of obj.type.values) {
                     if (v.color) {
-                        colors.pushColor(v.name, v.color);
+                        colors.setColor(v.name, v.color);
                     }
                 }
             }

--- a/app/components/comparison/shared/components/type.ts
+++ b/app/components/comparison/shared/components/type.ts
@@ -1,15 +1,19 @@
 import { LabelCls } from "./labelcls";
+import { ColorDictionary } from "./color-dictionary";
 
 export class Type {
     constructor(public tag: string = "",
                 public cls: string = "",
-                public labelCls: LabelCls = new LabelCls()) {
+                public labelCls: LabelCls = new LabelCls(),
+                public colors: ColorDictionary = new ColorDictionary()) {
     }
 
     public getCls(item: string): string {
         let labelClsString = this.labelCls.getCls(item);
-        if (this.cls == "" && labelClsString == "") {
+        if (this.cls == "" && labelClsString == "" && this.colors[item] === "") {
             return "label label-default";
+        } else if (this.cls == "" && labelClsString == "") {
+            return "label";
         } else if (labelClsString != "") {
             return "label " + labelClsString;
         } else {

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -28,7 +28,10 @@
                               *ngIf="column.type?.labelCls">
                         <ptooltip [tooltip]="column.values[sitem.content]"
                                   [tooltipHtml]="sitem.htmlChilds | citation: [citationServ]" [position]="'n'">
-                            <div class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}}  mylabel">
+                            <div *ngIf="(column.type.colors | json) == '{}'" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                                {{sitem.content + 'test'}}
+                            </div>
+                            <div *ngIf="(column.type.colors | json) != '{}'" [style.background-color]="getColor(column, sitem.content)" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
                         </ptooltip>

--- a/app/components/output/generic-table/generic-table.component.ts
+++ b/app/components/output/generic-table/generic-table.component.ts
@@ -5,6 +5,7 @@ import {
 import { TableData, Data, CriteriaSelection } from "./../../comparison/shared/index";
 import { ComparisonCitationService } from "./../../comparison/components/comparison-citation.service";
 import { ComparisonConfigService } from "../../comparison/components/comparison-config.service";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 
 @Component({
     selector: 'generictable',
@@ -37,7 +38,8 @@ export class GenericTableComponent implements AfterViewChecked {
     private ctrlCounter: number = 0;
 
     constructor(private ar: ApplicationRef,
-                private confServ: ComparisonConfigService) {
+                private confServ: ComparisonConfigService,
+                private sanitization: DomSanitizer) {
     }
 
     private orderClick(e: MouseEvent, value: string) {
@@ -91,5 +93,9 @@ export class GenericTableComponent implements AfterViewChecked {
             }
         }
         return val;
+    }
+
+    public getColor(column: TableData,label: string): SafeHtml {
+        return this.sanitization.bypassSecurityTrustStyle(column.type.colors.getColor(label));
     }
 }

--- a/comparison-configuration/criteria.json
+++ b/comparison-configuration/criteria.json
@@ -63,5 +63,23 @@
         "name": "light blue"
       }
     ]
+  },
+  {
+    "name": "Uncolored",
+    "tag": "Uncolored",
+    "description": "Tags that were originally uncolored.",
+    "placeholder": "Select color ...",
+    "and_search": false,
+    "values": [
+      {
+        "name": "color 1"
+      },
+      {
+        "name": "color 2"
+      },
+      {
+        "name": "color 3"
+      }
+    ]
   }
 ]

--- a/comparison-configuration/table.json
+++ b/comparison-configuration/table.json
@@ -116,5 +116,27 @@
         }
       ]
     }
+  },
+  {
+    "name": "Uncolored",
+    "tag": "Uncolored",
+    "display": true,
+    "type": {
+      "tag": "label",
+      "values": [
+        {
+          "name": "color 1",
+          "description": "Color 1"
+        },
+        {
+          "name": "color 2",
+          "description": "Color 2"
+        },
+        {
+          "name": "color 3",
+          "description": "Color 3"
+        }
+      ]
+    }
   }
 ]

--- a/comparison-elements/default.1.md
+++ b/comparison-elements/default.1.md
@@ -14,3 +14,7 @@ slow, MIT, red 1, grey
 
 ## Description
 Default long description in __markdown__.
+
+## Uncolored
+- color 1
+- color 2

--- a/comparison-elements/default.2.md
+++ b/comparison-elements/default.2.md
@@ -14,3 +14,7 @@ fast, Apache 2.0, red 2, green
 
 ## Description
 Default long description in __markdown__.
+
+## Uncolored
+- color 1
+- color 3

--- a/comparison-elements/default.3.md
+++ b/comparison-elements/default.3.md
@@ -14,3 +14,6 @@ fast, MPL 2.0, red 1, red 2, light blue
 
 ## Description
 Default long description in __markdown__.
+
+## Uncolored
+- color 2

--- a/comparison-elements/default.4.md
+++ b/comparison-elements/default.4.md
@@ -14,3 +14,6 @@ slow, MIT, green, green, grey
 
 ## Description
 Default long description in __markdown__.
+
+## Uncolored
+- color 1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,54 @@ var destfiles = {
 
 // BUILD / UPDATE data files -------------------------------------<
 gulp.task('build-data', function (callback) {
-    run('versioninfo', 'markdown', 'json', 'citation', callback);
+    run('versioninfo', 'determinecolors', 'markdown', 'json', 'citation', callback);
+})
+
+gulp.task('determinecolors', function() {
+    var factor = 0.5;
+    var input = './comparison-configuration/table.json';
+    var colorArray = [
+        '#EA3711',
+        '#11EAD3',
+        '#4F11EA',
+        '#EA6311',
+        '#C6EA11',
+        '#113FEA',
+        '#77EA11',
+        '#9811EA',
+        '#2BEA11',
+        '#EA9E11',
+        '#11BCEA',
+        '#11EA7A',
+        '#1E11EA',
+        '#EAD311',
+        '#8411EA',
+        '#BC11EA',
+        '#1187EA',
+        '#EA11BF'
+    ];
+    var color;
+    var startColor = color = 0;
+    var data = JSON.parse(fs.readFileSync(input, "utf8"));
+    var changed = false;
+    for (var i = 0; i < data.length; i++) {
+        color = startColor;
+        var o = data[i];
+        if (o.type.tag === "label") {
+            for (var j = 0; j < o.type.values.length; j++) {
+                var v = o.type.values[j];
+                if (!(v.hasOwnProperty("class") || v.hasOwnProperty("color"))) {
+                    v.color = colorArray[color];
+                    color++;
+                    changed = true;
+                }
+            }
+        }
+    }
+    if (changed) {
+        fs.writeFileSync(input, JSON.stringify(data, null, 4), "utf8");
+    }
+    return true;
 })
 
 gulp.task('versioninfo', function () {
@@ -48,8 +95,8 @@ gulp.task('versioninfo', function () {
     return gulp.src(versionfile)
         .pipe(rename(output))
         .pipe(gulp.dest('.'))
-        .pipe(exec('sed -ie "s/§§date§§/' + date.stdout.trim() + '/" ' + output))
-        .pipe(exec('sed -ie "s/§§commit§§/' + revision.stdout.trim() + '/g" ' + output));
+        .pipe(exec('sed -i "s/§§date§§/' + date.stdout.trim() + '/" ' + output))
+        .pipe(exec('sed -i "s/§§commit§§/' + revision.stdout.trim() + '/g" ' + output));
 })
 
 gulp.task('update-data', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ gulp.task('determinecolors', function() {
                 var v = o.type.values[j];
                 if (!(v.hasOwnProperty("class") || v.hasOwnProperty("color"))) {
                     v.color = colorArray[color];
-                    color++;
+                    color = (color + 1) % colorArray.length;
                     changed = true;
                 }
             }


### PR DESCRIPTION
it is now possible to add a color attribute to labels.
all valid css formats are allowed (eg. "red" or "#FF0000").
the value is directly inserted into the css.
fixes #13

if there is a value without class and color attribute, it gets an automatic value.
this is done at compile time and the original file is overwritten.

Example of automatically colored fields:
![image](https://cloud.githubusercontent.com/assets/7841099/25388059/060c3f24-29cd-11e7-8ee2-92359f588f9e.png)

order of colors that are applied:
![image](https://cloud.githubusercontent.com/assets/7841099/25388088/1d7e9cb0-29cd-11e7-8ce6-764d5dfb2eb8.png)
fixes #14

also fixes minor bug in gulp file that created app/VersionInformation.tse .
this is now prevented.

Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>