### PR TITLE
Fixes Issues 46, 47, 49, and 51

### DIFF
--- a/app/components/comparison/components/comparison-citation.service.ts
+++ b/app/components/comparison/components/comparison-citation.service.ts
@@ -20,11 +20,11 @@ export class ComparisonCitationService {
         for (let reference of this.references) {
             let key: any = reference;
             let entry: any = {"html": this.bibEntriesHtml[key]};
+            entry["key"] = key;
             entry["index"] = this.bibEntriesInline[key];
             entry["index"] = entry["index"].substr(1, entry["index"].length - 2);
             values.push(entry)
         }
-        console.log(values);
         return values.sort((a, b) => a.index - b.index);
     }
 

--- a/app/components/comparison/styles/comparison.component.css
+++ b/app/components/comparison/styles/comparison.component.css
@@ -29,6 +29,14 @@ comparison {
     padding: 10px;
 }
 
+pdialog {
+    z-index: 5000;
+}
+
+.floatThead-container {
+    z-index: 3000;
+}
+
 .ltable {
     display: none;
 }

--- a/app/components/input/select2/select2.component.css
+++ b/app/components/input/select2/select2.component.css
@@ -4,6 +4,10 @@
     width: 100% !important;
 }
 
+:host /deep/ div {
+    z-index: 3001;
+}
+
 :host /deep/ input {
     width: 100%;
 }

--- a/app/components/output/generic-table/generic-table.component.css
+++ b/app/components/output/generic-table/generic-table.component.css
@@ -29,7 +29,3 @@ table tr {
 table {
     width: auto;
 }
-
-ptooltip {
-    z-index: 3000;
-}

--- a/app/components/output/references-table/references-table.component.html
+++ b/app/components/output/references-table/references-table.component.html
@@ -4,7 +4,7 @@
             <td style="padding-right:10px;font-size:small;padding-top:3px;width:15%;" valign="top">
                 {{'[' + entry.index + ']'}}:
             </td>
-            <td [id]=entry [innerHtml]="entry.html|sanitizeHtml"></td>
+            <td [id]="entry.key" [innerHtml]="entry.html|sanitizeHtml"></td>
         </tr>
     </template>
 </table>

--- a/app/components/pipes/sanitizer-pipe/sanitizer.pipe.ts
+++ b/app/components/pipes/sanitizer-pipe/sanitizer.pipe.ts
@@ -11,7 +11,6 @@ export class SanitizerPipe implements PipeTransform {
     }
 
     transform(v: string): SafeHtml {
-        console.log("sanitize: " + v);
         let html = this._sanitizer.bypassSecurityTrustHtml(v);
         if (html.hasOwnProperty("changingThisBreaksApplicationSecurity") && /^<p>\d+\./.test(html["changingThisBreaksApplicationSecurity"])) {
             html["changingThisBreaksApplicationSecurity"] = "<p>" + html["changingThisBreaksApplicationSecurity"].substr(html["changingThisBreaksApplicationSecurity"].indexOf('.') + 1);

--- a/app/components/pipes/sanitizer-pipe/sanitizer.pipe.ts
+++ b/app/components/pipes/sanitizer-pipe/sanitizer.pipe.ts
@@ -11,8 +11,9 @@ export class SanitizerPipe implements PipeTransform {
     }
 
     transform(v: string): SafeHtml {
+        console.log("sanitize: " + v);
         let html = this._sanitizer.bypassSecurityTrustHtml(v);
-        if (html.hasOwnProperty("changingThisBreaksApplicationSecurity") && html["changingThisBreaksApplicationSecurity"].startsWith("<p>")) {
+        if (html.hasOwnProperty("changingThisBreaksApplicationSecurity") && /^<p>\d+\./.test(html["changingThisBreaksApplicationSecurity"])) {
             html["changingThisBreaksApplicationSecurity"] = "<p>" + html["changingThisBreaksApplicationSecurity"].substr(html["changingThisBreaksApplicationSecurity"].indexOf('.') + 1);
         }
         return html;

--- a/app/components/polymer/tooltip/tooltip.component.css
+++ b/app/components/polymer/tooltip/tooltip.component.css
@@ -13,12 +13,16 @@
     border-radius: 6px;
 
     position: absolute;
-    z-index: 1;
+    z-index: 4999;
 
     white-space: nowrap;
 
     transition-property: visibility;
     transition-duration: 0.1s;
+}
+
+:host .ptooltiptext /deep/ a {
+    color: lightgray;
 }
 
 :host .ptooltiptext /deep/ ul, :host .ptooltiptext /deep/ ol {

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -3,10 +3,6 @@ html {
     overflow: initial;
 }
 
-.cite-link {
+ptooltip div div p a.cite-link {
     color: lightgrey;
-}
-
-li a.cite-link {
-    color: #337ab7;
 }

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -2,7 +2,3 @@ html {
     overflow: auto;
     overflow: initial;
 }
-
-ptooltip div div p a.cite-link {
-    color: lightgrey;
-}


### PR DESCRIPTION
Issue #46: z-indexes were fixed and details are always in front of everything, then come the options for searching, then the table header.

Issue #47: revamped complete color assignment for citation links. only the ones in tooltips are grey.
![image](https://cloud.githubusercontent.com/assets/7841099/25491470/5bf49b6c-2b70-11e7-942c-6b9e7a5a0c72.png)

Issue #49: changed id of the entries in the references table. links are working again.

Issue #51: The matching for elements in the references table was too eager. The rule was refined via REGEX. instead of `/^<p>/` it is now `/^<p>\d+\./`

Screenshot for #46 and #51:
![image](https://cloud.githubusercontent.com/assets/7841099/25491532/893201a0-2b70-11e7-9d6e-247a6aa35230.png)
