### PR TITLE
Add support for missing attributes

### DIFF
--- a/app/components/pipes/orderby-pipe/orderby.pipe.ts
+++ b/app/components/pipes/orderby-pipe/orderby.pipe.ts
@@ -27,6 +27,16 @@ export class OrderByPipe implements PipeTransform {
             for (let i: number = 0; i < this.params.value.length; i++) {
                 if (this.params.option[i] == 0) continue;
                 let desc = this.params.option[i] == -1 ? true : false;
+                if (a.properties[this.params.value[i]] === undefined && b.properties[this.params.value[i]] === undefined) {
+                    // both elements lack the attribute => equivalent
+                    return 0;
+                } else if (a.properties[this.params.value[i]] === undefined) {
+                    // a lacks the attribute => it is always below the others
+                    return 1;
+                } else if (b.properties[this.params.value[i]] === undefined) {
+                    // b lacks the attribute => it is always below the others
+                    return -1;
+                }
                 let pA = a[this.params.value[i]] ? a[this.params.value[i]] : a.properties[this.params.value[i]].plain;
                 let pB = b[this.params.value[i]] ? b[this.params.value[i]] : b.properties[this.params.value[i]].plain;
                 let comparison = !desc ? OrderByPipe._comparator(pA, pB) : -OrderByPipe._comparator(pA, pB);


### PR DESCRIPTION
When you tried sorting after an attribute and an element didn't have
a value for it, errors were thrown.
This is now prevented by putting elements which miss the attribute to
the bottom of the list.
fixes #50 

default order:
![image](https://cloud.githubusercontent.com/assets/7841099/25492271/cf0d3224-2b72-11e7-8842-12aaa1f813e1.png)

ascending order:
![image](https://cloud.githubusercontent.com/assets/7841099/25492288/e454b170-2b72-11e7-8b4c-d780a67db448.png)

descending order:
![image](https://cloud.githubusercontent.com/assets/7841099/25492314/f6ed8c1c-2b72-11e7-8b02-15e672319da3.png)


Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>