### PR TITLE
Show Uncolored column and also labels for automatically colored ones

### DIFF
--- a/app/components/comparison/templates/comparison-details.template.html
+++ b/app/components/comparison/templates/comparison-details.template.html
@@ -28,7 +28,10 @@
                         <span class="{{getTable(atag)?.type?.getCls(sitem.content)}} mylabel">{{sitem.content}}</span>
                     </ptooltip>
                     <div *ngIf="confServ.comparison?.details.tooltipAsText">
-                        <span class="{{getTable(atag)?.type?.getCls(sitem.content)}} mylabel">{{sitem.content}}</span>
+                        <span *ngIf="(this.confServ.tableDataSet.getTableData(atag).type.colors | json).length === 21"
+                              class="{{getTable(atag)?.type?.getCls(sitem.content)}} mylabel">{{sitem.content}}</span>
+                        <span *ngIf="(this.confServ.tableDataSet.getTableData(atag).type.colors | json).length !== 21"
+                              class="label mylabel" [style.background-color]="this.confServ.tableDataSet.getTableData(atag).type.colors.getColor(sitem.content)">{{sitem.content}}</span>
                         <span class="tooltip-text">
                         <htmlcitationtext [description]="getTable(atag)?.values[sitem.content]"
                                           [citationServ]="citationServ"

--- a/comparison-configuration/comparison.json
+++ b/comparison-configuration/comparison.json
@@ -10,7 +10,8 @@
     "body-attachment-tags": [
       "Performance",
       "License",
-      "Showcase 2.0"
+      "Showcase 2.0",
+      "Uncolored"
     ]
   },
   "repository": "https://github.com/ultimate-comparisons/ultimate-comparison-BASE.git"


### PR DESCRIPTION
Both issues from #61 are resolved with this patch.

Uncolored had to be added in body-attachment-tags in comparison-configuration/comparison.json

added line for attributes that are automatically colored in app/components/comparison/templates/comparison-details.template.html