### PR TITLE
Add anchors to table rows

### DIFF
--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -18,7 +18,7 @@
     <template ngFor let-dat [ngForOf]="data | orderBy: [order,orderOption] | datafilter: [query, displayTemplate]">
         <tr *ngIf="shouldBeShown(dat)">
             <template ngFor let-column [ngForOf]="columns | tablefilter">
-                <td *ngIf="column.type?.tag==='url'"><a href="{{dat.getProperty(column.url).text}}" target="_blank">{{dat.getProperty(column.tag).text}}</a>
+                <td *ngIf="column.type?.tag==='url'"><a class="anchored" href="{{dat.getProperty(column.url).text}}" target="_blank">{{dat.getProperty(column.tag).text}}</a>
                 </td>
                 <td *ngIf="column.type?.tag==='text'">
                     <div [innerHtml]="dat.getProperty(column.tag).text|citation: [citationServ] | sanitizeHtml"></div>

--- a/app/components/output/generic-table/generic-table.component.ts
+++ b/app/components/output/generic-table/generic-table.component.ts
@@ -6,6 +6,7 @@ import { TableData, Data, CriteriaSelection } from "./../../comparison/shared/in
 import { ComparisonCitationService } from "./../../comparison/components/comparison-citation.service";
 import { ComparisonConfigService } from "../../comparison/components/comparison-config.service";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
+declare let anchors;
 
 @Component({
     selector: 'generictable',
@@ -77,6 +78,10 @@ export class GenericTableComponent implements AfterViewChecked {
     ngAfterViewChecked(): void {
         const t = (<any>$("table.table.table-hover"));
         t.floatThead();
+        anchors.options = {
+            placement: 'right'
+        };
+        anchors.add('.anchored');
     }
 
     public shouldBeShown(data: Data) {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/floatthead/2.0.3/jquery.floatThead.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.2/anchor.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
next to the name of the comparison element will be an anchor.

the anchor is right of the name of the element.

image showing the anchor
![image](https://cloud.githubusercontent.com/assets/7841099/26530452/139f2170-43d5-11e7-880c-10c0ede5e7cc.png)


fixes: #69 
Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>