### PR TITLE
check if values array exists

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ gulp.task('determinecolors', function() {
     for (var i = 0; i < data.length; i++) {
         color = startColor;
         var o = data[i];
-        if (o.type.tag === "label") {
+        if (o.type.tag === "label" && o.type.values != null) {
             for (var j = 0; j < o.type.values.length; j++) {
                 var v = o.type.values[j];
                 if (!(v.hasOwnProperty("class") || v.hasOwnProperty("color"))) {


### PR DESCRIPTION
before checking if a color needs to be added to a color, gulp checks if any value exists at all.

fix #63
Signed-off-by: Armin Hueneburg <hueneburg.armin@gmail.com>