### PR TITLE
Set table anchores 48px higher

### DIFF
--- a/app/components/output/generic-table/generic-table.component.css
+++ b/app/components/output/generic-table/generic-table.component.css
@@ -29,3 +29,10 @@ table tr {
 table {
     width: auto;
 }
+
+.anchored::before {
+    content: '';
+    display: block;
+    height:48px;
+    margin:-48px 0 0;
+}


### PR DESCRIPTION
Clicking on an anchor in the table resulted in an element hidden beneath the table header.
This is now resolved.
The anchor jumps 48px higher than the anchor.

solves #75

example of jumping to Default 4:
![image](https://user-images.githubusercontent.com/7841099/27091848-a84bd3d4-5061-11e7-9645-760b89f2448f.png)
