### PR TITLE
Add style to unknown criteria values

### DIFF
--- a/app/components/comparison/shared/components/color-dictionary.ts
+++ b/app/components/comparison/shared/components/color-dictionary.ts
@@ -12,4 +12,8 @@ export class ColorDictionary {
             return "";
         }
     }
+
+    public isEmpty(): boolean {
+        return Object.keys(this.colorDict).length === 0;
+    }
 }

--- a/app/components/output/generic-table/generic-table.component.css
+++ b/app/components/output/generic-table/generic-table.component.css
@@ -15,6 +15,11 @@ table {
     white-space: inherit;
 }
 
+.label-unknown {
+    color: black;
+    border: solid black 1px;
+}
+
 th > button {
     border: none;
     padding: 0;

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -28,10 +28,10 @@
                               *ngIf="column.type?.labelCls">
                         <ptooltip [tooltip]="column.values[sitem.content]"
                                   [tooltipHtml]="sitem.htmlChilds | citation: [citationServ]" [position]="'n'">
-                            <div *ngIf="(column.type.colors | json) == '{}'" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
-                                {{sitem.content + 'test'}}
+                            <div *ngIf="(column.type.colors | json) == ({colorDict: {}} | json)" [ngClass]="{'label-unknown': column.type.labelCls.getCls(sitem.content).length + column.type.getCls(sitem.content).length === 5}" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                                {{sitem.content}}
                             </div>
-                            <div *ngIf="(column.type.colors | json) != '{}'" [style.background-color]="getColor(column, sitem.content)" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                            <div *ngIf="(column.type.colors | json) != ({colorDict: {}} | json)" [style.background-color]="getColor(column, sitem.content)" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
                         </ptooltip>

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -28,10 +28,10 @@
                               *ngIf="column.type?.labelCls">
                         <ptooltip [tooltip]="column.values[sitem.content]"
                                   [tooltipHtml]="sitem.htmlChilds | citation: [citationServ]" [position]="'n'">
-                            <div *ngIf="(column.type.colors | json) == ({colorDict: {}} | json)" [ngClass]="{'label-unknown': column.type.labelCls.getCls(sitem.content).length + column.type.getCls(sitem.content).length === 5}" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                            <div *ngIf="column.type.colors.isEmpty()" [ngClass]="{'label-unknown': column.type.labelCls.getCls(sitem.content).length + column.type.getCls(sitem.content).length === 5}" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
-                            <div *ngIf="(column.type.colors | json) != ({colorDict: {}} | json)" [style.background-color]="getColor(column, sitem.content)" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                            <div *ngIf="!column.type.colors.isEmpty()" [style.background-color]="getColor(column, sitem.content)" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
                         </ptooltip>


### PR DESCRIPTION
Values of criteria that were not documented in table.json were almost not visible.
This path adds a black border and black text color to these labels.
The different style signifies creators that there are values that are not documented and the border
allows differentiating between different labels (eg. 'slow medium' and 'slow' + 'medium'
couldn't be differentiated)

solves #68

example:
![image](https://user-images.githubusercontent.com/7841099/27093301-767ef782-5066-11e7-94ff-23812a9b3f23.png)
