### PR TITLE
Exchange colors for pastel variants

### DIFF
--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -31,7 +31,7 @@
                             <div *ngIf="column.type.colors.isEmpty()" [ngClass]="{'label-unknown': column.type.labelCls.getCls(sitem.content).length + column.type.getCls(sitem.content).length === 5}" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
-                            <div *ngIf="!column.type.colors.isEmpty()" [style.background-color]="getColor(column, sitem.content)" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                            <div *ngIf="!column.type.colors.isEmpty()" [style.background-color]="getColor(column, sitem.content)" [style.color]="'#808080'" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
                         </ptooltip>

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -31,7 +31,7 @@
                             <div *ngIf="column.type.colors.isEmpty()" [ngClass]="{'label-unknown': column.type.labelCls.getCls(sitem.content).length + column.type.getCls(sitem.content).length === 5}" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
-                            <div *ngIf="!column.type.colors.isEmpty()" [style.background-color]="getColor(column, sitem.content)" [style.color]="'#808080'" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
+                            <div *ngIf="!column.type.colors.isEmpty()" [style.background-color]="getColor(column, sitem.content)" [style.color]="getForegroundColor(getColor(column, sitem.content))" class="{{column.type.getCls(sitem.content)}} {{column.type.labelCls.getCls(sitem.content)}} mylabel">
                                 {{sitem.content}}
                             </div>
                         </ptooltip>

--- a/app/components/output/generic-table/generic-table.component.ts
+++ b/app/components/output/generic-table/generic-table.component.ts
@@ -122,4 +122,38 @@ export class GenericTableComponent implements AfterViewChecked, OnChanges {
     public getColor(column: TableData, label: string): SafeHtml {
         return this.sanitization.bypassSecurityTrustStyle(column.type.colors.getColor(label));
     }
+
+    public getForegroundColor(color: any): SafeHtml {
+        const h = Number.parseInt(color["changingThisBreaksApplicationSecurity"].substr(4, 3).split(',')[0]);
+        const s = 100;
+        const l = 88;
+        const rgb = this.hslToRgb(h, s, l);
+        const yiq = ((rgb[0]*299)+(rgb[1]*587)+(rgb[2]*114))/1000;
+        return this.sanitization.bypassSecurityTrustStyle((yiq >= 128) ? 'black' : 'white');
+    }
+
+    private hslToRgb(h, s, l){
+        let r, g, b;
+
+        if(s == 0){
+            r = g = b = l; // achromatic
+        }else{
+            let hue2rgb = function hue2rgb(p, q, t){
+                if(t < 0) t += 1;
+                if(t > 1) t -= 1;
+                if(t < 1/6) return p + (q - p) * 6 * t;
+                if(t < 1/2) return q;
+                if(t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+                return p;
+            }
+
+            let q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+            let p = 2 * l - q;
+            r = hue2rgb(p, q, h + 1/3);
+            g = hue2rgb(p, q, h);
+            b = hue2rgb(p, q, h - 1/3);
+        }
+
+        return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+    }
 }

--- a/comparison-configuration/table.json
+++ b/comparison-configuration/table.json
@@ -59,17 +59,17 @@
                 {
                     "name": "MIT",
                     "description": "<http://choosealicense.com/licenses/mit/>",
-                    "color": "#EA3711"
+                    "color": "hsl(174, 100%, 88%)"
                 },
                 {
                     "name": "Apache 2.0",
                     "description": "http://choosealicense.com/licenses/apache-2.0/",
-                    "color": "#11EAD3"
+                    "color": "hsl(257, 100%, 88%)"
                 },
                 {
                     "name": "MPL 2.0",
                     "description": "http://choosealicense.com/licenses/mpl-2.0/",
-                    "color": "#4F11EA"
+                    "color": "hsl(23, 100%, 88%)"
                 }
             ]
         }
@@ -140,19 +140,19 @@
                     "name": "color 1",
                     "description": "Color 1",
                     "weight": 1,
-                    "color": "#EA3711"
+                    "color": "hsl(174, 100%, 88%)"
                 },
                 {
                     "name": "color 2",
                     "description": "Color 2",
                     "weight": 2,
-                    "color": "#11EAD3"
+                    "color": "hsl(257, 100%, 88%)"
                 },
                 {
                     "name": "color 3",
                     "description": "Color 3",
                     "weight": 3,
-                    "color": "#4F11EA"
+                    "color": "hsl(23, 100%, 88%)"
                 }
             ]
         }

--- a/comparison-configuration/table.json
+++ b/comparison-configuration/table.json
@@ -59,17 +59,17 @@
                 {
                     "name": "MIT",
                     "description": "<http://choosealicense.com/licenses/mit/>",
-                    "color": "hsl(174, 100%, 88%)"
+                    "color": "hsl(000, 100%, 88%)"
                 },
                 {
                     "name": "Apache 2.0",
                     "description": "http://choosealicense.com/licenses/apache-2.0/",
-                    "color": "hsl(257, 100%, 88%)"
+                    "color": "hsl(75, 100%, 88%)"
                 },
                 {
                     "name": "MPL 2.0",
                     "description": "http://choosealicense.com/licenses/mpl-2.0/",
-                    "color": "hsl(23, 100%, 88%)"
+                    "color": "hsl(150, 100%, 88%)"
                 }
             ]
         }
@@ -140,19 +140,19 @@
                     "name": "color 1",
                     "description": "Color 1",
                     "weight": 1,
-                    "color": "hsl(174, 100%, 88%)"
+                    "color": "hsl(225, 100%, 88%)"
                 },
                 {
                     "name": "color 2",
                     "description": "Color 2",
                     "weight": 2,
-                    "color": "hsl(257, 100%, 88%)"
+                    "color": "hsl(300, 100%, 88%)"
                 },
                 {
                     "name": "color 3",
                     "description": "Color 3",
                     "weight": 3,
-                    "color": "hsl(23, 100%, 88%)"
+                    "color": "hsl(15, 100%, 88%)"
                 }
             ]
         }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,24 +44,23 @@ gulp.task('determinecolors', function() {
     var factor = 0.5;
     var input = './comparison-configuration/table.json';
     var colorArray = [
-        '#EA3711',
-        '#11EAD3',
-        '#4F11EA',
-        '#EA6311',
-        '#C6EA11',
-        '#113FEA',
-        '#77EA11',
-        '#9811EA',
-        '#2BEA11',
-        '#EA9E11',
-        '#11BCEA',
-        '#11EA7A',
-        '#1E11EA',
-        '#EAD311',
-        '#8411EA',
-        '#BC11EA',
-        '#1187EA',
-        '#EA11BF'
+        'hsl(174, 100%, 88%)',
+        'hsl(257, 100%, 88%)',
+        'hsl(23, 100%, 88%)',
+        'hsl(70, 100%, 88%)',
+        'hsl(227, 100%, 88%)',
+        'hsl(92, 100%, 88%)',
+        'hsl(277, 100%, 88%)',
+        'hsl(113, 100%, 88%)',
+        'hsl(39, 100%, 88%)',
+        'hsl(193, 100%, 88%)',
+        'hsl(149, 100%, 88%)',
+        'hsl(244, 100%, 88%)',
+        'hsl(54, 100%, 88%)',
+        'hsl(272, 100%, 88%)',
+        'hsl(287, 100%, 88%)',
+        'hsl(207, 100%, 88%)',
+        'hsl(312, 100%, 88%)'
     ];
     var color;
     var startColor = color = 0;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var gulp = require('gulp'),
     bibtex2json = require('./citation/bibtex2json'),
     fs = require('fs'),
     sh = require('sync-exec');
+var startColor = color = 0;
 
 var paths = {
     src: 'app',
@@ -44,42 +45,48 @@ gulp.task('determinecolors', function() {
     var factor = 0.5;
     var input = './comparison-configuration/table.json';
     var colorArray = [
-        'hsl(174, 100%, 88%)',
-        'hsl(257, 100%, 88%)',
-        'hsl(23, 100%, 88%)',
-        'hsl(70, 100%, 88%)',
-        'hsl(227, 100%, 88%)',
-        'hsl(92, 100%, 88%)',
-        'hsl(277, 100%, 88%)',
-        'hsl(113, 100%, 88%)',
-        'hsl(39, 100%, 88%)',
-        'hsl(193, 100%, 88%)',
-        'hsl(149, 100%, 88%)',
-        'hsl(244, 100%, 88%)',
-        'hsl(54, 100%, 88%)',
-        'hsl(272, 100%, 88%)',
-        'hsl(287, 100%, 88%)',
-        'hsl(207, 100%, 88%)',
-        'hsl(312, 100%, 88%)'
+        'hsl(000, 100%, 88%)',
+        'hsl(15, 100%, 88%)',
+        'hsl(30, 100%, 88%)',
+        'hsl(45, 100%, 88%)',
+        'hsl(60, 100%, 88%)',
+        'hsl(75, 100%, 88%)',
+        'hsl(90, 100%, 88%)',
+        'hsl(105, 100%, 88%)',
+        'hsl(120, 100%, 88%)',
+        'hsl(135, 100%, 88%)',
+        'hsl(150, 100%, 88%)',
+        'hsl(165, 100%, 88%)',
+        'hsl(180, 100%, 88%)',
+        'hsl(195, 100%, 88%)',
+        'hsl(210, 100%, 88%)',
+        'hsl(225, 100%, 88%)',
+        'hsl(240, 100%, 88%)',
+        'hsl(255, 100%, 88%)',
+        'hsl(270, 100%, 88%)',
+        'hsl(285, 100%, 88%)',
+        'hsl(300, 100%, 88%)',
+        'hsl(315, 100%, 88%)',
+        'hsl(330, 100%, 88%)',
+        'hsl(345, 100%, 88%)'
     ];
-    var color;
-    var startColor = color = 0;
+    var color = startColor;
     var data = JSON.parse(fs.readFileSync(input, "utf8"));
     var changed = false;
     for (var i = 0; i < data.length; i++) {
-        color = startColor;
         var o = data[i];
         if (o.type.tag === "label" && o.type.values != null) {
             for (var j = 0; j < o.type.values.length; j++) {
                 var v = o.type.values[j];
                 if (!(v.hasOwnProperty("class") || v.hasOwnProperty("color"))) {
                     v.color = colorArray[color];
-                    color = (color + 1) % colorArray.length;
+                    color = (color + 5) % colorArray.length;
                     changed = true;
                 }
             }
         }
     }
+    startColor = color;
     if (changed) {
         fs.writeFileSync(input, JSON.stringify(data, null, 4), "utf8");
     }


### PR DESCRIPTION
Removed the first color (almost not visible as pastel) and transformed rest to pastel.
This was done via RGB -> HSL transformation and transforming HSL colors to pastel as
described in https://kentor.me/posts/generating-pastel-colors-for-css/
Tool for RGB->HSL: http://www.rapidtables.com/convert/color/rgb-to-hsv.htm

Because the white writing on pastel colors was almost not visible, I added a foreground
color (#808080) to elments that used auto coloring.

Example:
without foreground color:
![image](https://user-images.githubusercontent.com/7841099/27871537-387467c8-61a6-11e7-9cab-a2594dcd7abc.png)


with foreground color:
![image](https://user-images.githubusercontent.com/7841099/27871610-725c2a20-61a6-11e7-8d1c-aa990c2dd94d.png)
