### PR TITLE
Add number columns with range search

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This is an ultimate comparison framework written in [Angular](https://angular.io
   - `placeholder:` Placeholder for the select box.
   - `values:` Filter values.
   - `and_search:` Defines if all filter value must match or at least one.
+  - `number_search`: Allow range searches. Ignores given values.
   
   ![criteria.json](https://cdn.rawgit.com/ultimate-comparisons/ultimate-comparison-BASE/master/media/criteria.svg)       
         

--- a/app/components/comparison/shared/components/criteria.set.ts
+++ b/app/components/comparison/shared/components/criteria.set.ts
@@ -10,14 +10,17 @@ export class CriteriaSet {
             criteria.tag = crit.tag;
             criteria.description = crit.description ? crit.description : "";
             criteria.and_search = typeof crit.and_search !== typeof undefined ? crit.and_search : true;
-            crit.values.forEach(val => {
-                let value: Value = new Value();
-                value.name = val.name ? val.name : "undefined value";
-                value.value = val.name ? val.name : "undefined value";
-                value.label = val.name ? val.name : "undefined value";
-                value.description = val.description ? val.description : "";
-                criteria.values.push(value);
-            });
+            criteria.range_search = typeof crit.range_search !== typeof undefined ? crit.range_search : false;
+            if (!criteria.range_search) {
+                crit.values.forEach(val => {
+                    let value: Value = new Value();
+                    value.name = val.name ? val.name : "undefined value";
+                    value.value = val.name ? val.name : "undefined value";
+                    value.label = val.name ? val.name : "undefined value";
+                    value.description = val.description ? val.description : "";
+                    criteria.values.push(value);
+                });
+            }
             criteria.placeholder = crit.placeholder ? crit.placeholder : "";
             this.criteriaSet[crit.tag] = criteria;
         });

--- a/app/components/comparison/shared/components/criteria.ts
+++ b/app/components/comparison/shared/components/criteria.ts
@@ -4,7 +4,17 @@ export class Criteria {
                 public description: string = "",
                 public placeholder: string = "",
                 public and_search: boolean = true,
-                public values: Array<Object> = new Array<Object>()) {
+                public values: Array<Object> = new Array<Object>(),
+                public range_search: boolean = false) {
     }
 
+    public getSearchIndicator(): String {
+        if (this.and_search) {
+            return "match all";
+        }
+        if (this.range_search) {
+            return "match range";
+        }
+        return "match one";
+    }
 }

--- a/app/components/comparison/styles/comparison.component.css
+++ b/app/components/comparison/styles/comparison.component.css
@@ -96,3 +96,13 @@ pdialog {
     font-size: 8pt;
     opacity: 80;
 }
+
+.range-search {
+    border: 0px !important;
+    border-bottom: 1px solid #aaa !important;
+    border-radius: 0px !important;
+}
+
+.range-search:focus {
+    outline-width: 0;
+}

--- a/app/components/comparison/templates/comparison.template.html
+++ b/app/components/comparison/templates/comparison.template.html
@@ -31,11 +31,13 @@
                         <ptooltip [tooltip]="crit.description">
                             <label>
                                 {{crit.name}}
-                                <span class="search-indicator">({{crit.and_search ? "match all" : "match one"}})</span>
+                                <span class="search-indicator">({{crit.getSearchIndicator()}})</span>
                             </label>
-                        </ptooltip>
+                        </ptooltip><br>
                         <select2 [options]="crit.values" [placeholder]="crit.placeholder"
-                                 (result)="criteriaChanged($event, crit)"></select2>
+                                 (result)="criteriaChanged($event, crit)" *ngIf="!crit.range_search"></select2>
+                        <input type="text" [placeholder]="crit.placeholder" [style.width]="'100%'"
+                               (keyup)="criteriaChanged($event, crit)" *ngIf="crit.range_search">
                     </div>
                 </div>
             </template>

--- a/app/components/comparison/templates/comparison.template.html
+++ b/app/components/comparison/templates/comparison.template.html
@@ -36,7 +36,7 @@
                         </ptooltip><br>
                         <select2 [options]="crit.values" [placeholder]="crit.placeholder"
                                  (result)="criteriaChanged($event, crit)" *ngIf="!crit.range_search"></select2>
-                        <input type="text" [placeholder]="crit.placeholder" [style.width]="'100%'"
+                        <input type="text" [placeholder]="crit.placeholder" [style.width]="'100%'" class="range-search"
                                (keyup)="criteriaChanged($event, crit)" *ngIf="crit.range_search">
                     </div>
                 </div>

--- a/app/components/pipes/data-pipe/data.pipe.ts
+++ b/app/components/pipes/data-pipe/data.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import { Data } from "./../../comparison/shared/index";
+import { ListItem } from "../../comparison/shared/components/list-item";
 
 @Pipe({
     name: 'datafilter',
@@ -20,8 +21,26 @@ export class DataPipe implements PipeTransform {
                 if (!this.query.hasOwnProperty(key)) continue;
                 let cont = this.query[key];
                 let values: Array<string> = item.getPropertyTags(cont.criteria.tag);
-                if (!((cont.values.length < 1) || (this.intersect(cont.values, values, cont.criteria.and_search)))) {
+                if (cont.criteria.range_search) {
+                    let value = cont.values.target.value;
+                    value = value.replace(/ /g, "");
+                    const tokens = value.split(",");
+                    for (const token of tokens) {
+                        if (token.lastIndexOf("-") >= 1) {
+                            if (this.rangeSearch(token, item.properties[cont.criteria.tag].list)) {
+                                return true;
+                            }
+                        } else {
+                            if (this.numberSearch(Number.parseFloat(token), item.properties[cont.criteria.tag].list)) {
+                                return true;
+                            }
+                        }
+                    }
                     return false;
+                } else {
+                    if (!((cont.values.length < 1) || (this.intersect(cont.values, values, cont.criteria.and_search)))) {
+                        return false;
+                    }
                 }
             }
             return true;
@@ -55,5 +74,56 @@ export class DataPipe implements PipeTransform {
             return true;
         }
         return inter;
+    }
+
+    private rangeSearch(range: string, list: Array<ListItem>) {
+        let negativeMin = false;
+        if (range.startsWith("-")) {
+            negativeMin = true;
+            range = range.substr(1);
+        }
+        let negativeMax = false;
+        if (range.indexOf("--") + 1 == range.lastIndexOf("-")) {
+            negativeMax = true;
+        }
+        const rValues = range.split(/-/).filter(el => el.length !== 0);
+        if (rValues.length < 2) {
+            return this.numberSearch(Number.parseFloat(rValues[0]), list);
+        }
+        rValues[1] = rValues[rValues.length - 1];
+        let min = Number.parseFloat(rValues[0]);
+        if (negativeMin) {
+            min *= -1;
+        }
+        let max = Number.parseFloat(rValues[1]);
+        if (negativeMax) {
+            max *= -1;
+        }
+        if (max < min) {
+            const t = max;
+            max = min;
+            min = t;
+        }
+
+        for (const item of list) {
+            const n = Number.parseFloat(item.content);
+            if (min <= n && n <= max) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private numberSearch(number: number, list: Array<ListItem>) {
+        if (isNaN(number)) {
+            return false;
+        }
+
+        for (let item of list) {
+            if (Number.parseFloat(item.content) === number) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/app/components/pipes/data-pipe/data.pipe.ts
+++ b/app/components/pipes/data-pipe/data.pipe.ts
@@ -24,6 +24,9 @@ export class DataPipe implements PipeTransform {
                 if (cont.criteria.range_search) {
                     let value = cont.values.target.value;
                     value = value.replace(/ /g, "");
+                    if (value.length === 0) {
+                        return true;
+                    }
                     const tokens = value.split(",");
                     for (const token of tokens) {
                         if (token.lastIndexOf("-") >= 1) {

--- a/comparison-configuration/criteria.json
+++ b/comparison-configuration/criteria.json
@@ -81,5 +81,13 @@
         "name": "color 3"
       }
     ]
+  },
+  {
+    "name": "Number Column",
+    "tag": "NumberColumn",
+    "description": "Tags that were originally numbered.",
+    "placeholder": "Select number ranges ...",
+    "and_search": false,
+    "range_search": true
   }
 ]

--- a/comparison-configuration/table.json
+++ b/comparison-configuration/table.json
@@ -156,5 +156,46 @@
                 }
             ]
         }
+    },
+    {
+        "name": "Number Column",
+        "tag": "NumberColumn",
+        "display": true,
+        "order": "asc",
+        "type": {
+            "tag": "label",
+            "values": [
+                {
+                    "name": 100,
+                    "description": 100,
+                    "weight": 1,
+                    "color": "#EA3711"
+                },
+                {
+                    "name": 200,
+                    "description": 200,
+                    "weight": 2,
+                    "color": "#11EAD3"
+                },
+                {
+                    "name": 250,
+                    "description": 250,
+                    "weight": 3,
+                    "color": "#4F11EA"
+                },
+                {
+                    "name": 300,
+                    "description": 300,
+                    "weight": 4,
+                    "color": "#EA6311"
+                },
+                {
+                    "name": 199,
+                    "description": 199,
+                    "weight": 1.99,
+                    "color": "#C6EA11"
+                }
+            ]
+        }
     }
 ]

--- a/comparison-elements/default.1.md
+++ b/comparison-elements/default.1.md
@@ -18,3 +18,7 @@ Default long description in __markdown__.
 ## Uncolored
 - color 1
 - color 2
+
+## NumberColumn
+- 200
+- 199

--- a/comparison-elements/default.2.md
+++ b/comparison-elements/default.2.md
@@ -18,3 +18,6 @@ Default long description in __markdown__.
 ## Uncolored
 - color 1
 - color 3
+
+## NumberColumn
+- 300

--- a/comparison-elements/default.3.md
+++ b/comparison-elements/default.3.md
@@ -17,3 +17,6 @@ Default long description in __markdown__.
 
 ## Uncolored
 - color 2
+
+## NumberColumn
+- 250

--- a/comparison-elements/default.4.md
+++ b/comparison-elements/default.4.md
@@ -18,3 +18,6 @@ Default long description in __markdown__.
 
 ## Uncolored
 - color 1
+
+## NumberColumn
+- 100

--- a/comparison-elements/template.md
+++ b/comparison-elements/template.md
@@ -32,3 +32,9 @@ Default long description in __markdown__.
 - [5] Template is perfect
 - [1] I don't understand nothing
 - [3] It works
+
+## Uncolored
+- color 1
+
+## NumberColumn
+- 200


### PR DESCRIPTION
Added number columns/criteria that don't filter according to values but to ranges.
Filtering allows multiple ranges/values separated by commas.
An example would look like this: `100,200-250`
Both min and max are inclusive.
Ranges max to min (eg `200-100`) are handled as well.
NaN ranges are ignored.
It is also possible to add multiple numbers in a column and it tests if one is in range.
whitespaces are completely ignored, so that `2 000` is equal to `2000`.

original display:
![image](https://user-images.githubusercontent.com/7841099/27878198-b49b008e-61bd-11e7-922a-bdf0d8015d75.png)


simple filter:
![image](https://user-images.githubusercontent.com/7841099/27878231-cd8287b6-61bd-11e7-92ee-2d7e39210259.png)


range filter:
![image](https://user-images.githubusercontent.com/7841099/27878252-df7edad2-61bd-11e7-8d12-091d3682d560.png)


mixed filter:
![image](https://user-images.githubusercontent.com/7841099/27878275-f3499ad4-61bd-11e7-8f9d-b58db6af0d62.png)


filter with NaN:
![image](https://user-images.githubusercontent.com/7841099/27878294-0748cc8a-61be-11e7-84a2-4945c841e0c1.png)


solves #56 