### PR TITLE
Show unknown if no value is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added force push for deployment
 - Moved deployment to .travis.yml
 - Added tslint
+- Added unknown label for empty values
 
 ### Fixed
 - Rate Limit exceeded for GitHub for up to 60 elements.

--- a/app/components/comparison/components/comparison-data.service.ts
+++ b/app/components/comparison/components/comparison-data.service.ts
@@ -78,7 +78,11 @@ export class ComparisonDataService {
 
     public getRepoData(data: Data, repo: string) {
         repo = repo.replace(/^-\s*/, "");
-        this.http.get(this.repoQueryBuildUrl(repo)).toPromise()
+        const url = this.repoQueryBuildUrl(repo);
+        if (url === null) {
+            return;
+        }
+        this.http.get(url).toPromise()
             .then(function (res) {
                 const body = JSON.parse(res["_body"]);
                 const date = moment(body[0].commit.author.date);
@@ -91,6 +95,9 @@ export class ComparisonDataService {
     }
 
     private repoQueryBuildUrl(repoUrl: string) {
+        if (!repoUrl) {
+            return null;
+        }
         let url: string;
         if (/https?:\/\/github\.com.*/.test(repoUrl.trim())) {
             url = repoUrl.trim().replace(/https?:\/\/github.com/, "https://api.github.com/repos");

--- a/app/components/output/generic-table/generic-table.component.css
+++ b/app/components/output/generic-table/generic-table.component.css
@@ -49,3 +49,8 @@ table {
     height:48px;
     margin:-48px 0 0;
 }
+
+.unknown {
+    background-color: lightgray;
+    color: white;
+}

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -36,6 +36,9 @@
                             </div>
                         </ptooltip>
                     </template>
+                    <ptooltip *ngIf="dat.getPropertyListItems(column.tag).length === 0" [tooltipHtml]="'The semantics of this value are unknown'">
+                        <div class="label mylabel unknown">unknown</div>
+                    </ptooltip>
                 </td>
                 <td *ngIf="column.type?.tag==='label' && column.repo">
                     <template ngFor let-sitem [ngForOf]="dat.getRepoLabels(column, cd)?.list"
@@ -49,6 +52,9 @@
                             </div>
                         </ptooltip>
                     </template>
+                    <ptooltip *ngIf="dat.getRepoLabels(column, cd) === undefined" [tooltipHtml]="'The semantics of this value are unknown'">
+                        <div class="label mylabel unknown">unknown</div>
+                    </ptooltip>
                 </td>
                 <td *ngIf="column.type?.tag=='rating'">
                     <iicon icon="star" *ngIf="dat.getRating()!=0">{{dat.getRating()}}</iicon>

--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -36,7 +36,7 @@
                             </div>
                         </ptooltip>
                     </template>
-                    <ptooltip *ngIf="dat.getPropertyListItems(column.tag).length === 0" [tooltipHtml]="'The semantics of this value are unknown'">
+                    <ptooltip *ngIf="dat.getPropertyListItems(column.tag).length === 0" [tooltipHtml]="'There was no value for this field. Please submit one via pull request.'">
                         <div class="label mylabel unknown">unknown</div>
                     </ptooltip>
                 </td>
@@ -52,7 +52,7 @@
                             </div>
                         </ptooltip>
                     </template>
-                    <ptooltip *ngIf="dat.getRepoLabels(column, cd) === undefined" [tooltipHtml]="'The semantics of this value are unknown'">
+                    <ptooltip *ngIf="dat.getRepoLabels(column, cd) === undefined" [tooltipHtml]="'There was no value for this field. Please submit one via pull request.'">
                         <div class="label mylabel unknown">unknown</div>
                     </ptooltip>
                 </td>

--- a/comparison-elements/default.5.md
+++ b/comparison-elements/default.5.md
@@ -1,0 +1,17 @@
+# Default 5 - http://default-5-entry.example.com
+almost everything unknown
+
+## Performance
+
+## License
+
+## Showcase 2.0
+
+## Description
+This element has almost no values to test unknown
+
+## Uncolored
+
+## Repo
+
+## NumberColumn


### PR DESCRIPTION
If no value is given, the cell was empty which might not have transferred the correct semantics.
Now, there is a lightgray field with white font.

Fixes #106 