### PR TITLE
Fix sorting of repo columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed problem with sorting `repo` columns [#114](https://github.com/ultimate-comparisons/ultimate-comparison-BASE/issues/114)
+
 ## 1.0.0 - 2017-08-24
 ### Added
 - This file
@@ -18,3 +22,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Rate Limit exceeded for GitHub for up to 60 elements.
+- Fixed problem with sorting `repo` columns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Rate Limit exceeded for GitHub for up to 60 elements.
-- Fixed problem with sorting `repo` columns

--- a/app/components/comparison/components/comparison-data.service.ts
+++ b/app/components/comparison/components/comparison-data.service.ts
@@ -76,7 +76,8 @@ export class ComparisonDataService {
             });
     }
 
-    public getRepoData(data: Data, repo: string) {
+    public getRepoData(data: Data, repo: string | number) {
+        repo = <string> repo;
         repo = repo.replace(/^-\s*/, "");
         const url = this.repoQueryBuildUrl(repo);
         if (url === null) {

--- a/app/components/comparison/components/comparison-details.component.ts
+++ b/app/components/comparison/components/comparison-details.component.ts
@@ -4,6 +4,7 @@ import { ComparisonConfigService } from './comparison-config.service';
 import { ComparisonDataService } from './comparison-data.service';
 import { ComparisonService } from './comparison.service';
 import { ComparisonCitationService } from './comparison-citation.service';
+import { isNullOrUndefined } from "util";
 
 @Component({
     selector: 'comparison-details',
@@ -37,9 +38,12 @@ export class ComparisonDetailsComponent {
     }
 
     private getBody(): string {
+        let data = <string> this.data.getProperty(this.confServ.comparison.details.body).plain;
+        if (isNullOrUndefined(data)) {
+            data = String(this.data.getProperty(this.confServ.comparison.details.body).plain);
+        }
         const body = this.confServ.comparison ?
-            this.serv.converter.makeHtml(this.data.getProperty(this.confServ.comparison.details.body).plain) :
-            '';
+            this.serv.converter.makeHtml(data) : '';
         if (body && body !== this.body) {
             this.body = body;
         }

--- a/app/components/comparison/shared/components/data.ts
+++ b/app/components/comparison/shared/components/data.ts
@@ -110,6 +110,7 @@ export class Data {
 
             if ((min === -1 || minDiff >= min) && (max === -1 || maxDiff < max)) {
                 this.properties[td.tag].list.push(new ListItem(key, child, this.comparisonService.converter));
+                this.properties[td.tag].plain = Math.abs(now.diff(current));
                 return this.properties[td.tag];
             }
         }

--- a/app/components/comparison/shared/components/property.ts
+++ b/app/components/comparison/shared/components/property.ts
@@ -1,7 +1,7 @@
 import { ListItem } from './list-item';
 
 export class Property {
-    constructor(public plain = '',
+    constructor(public plain: string | number = '',
                 public text = '',
                 public list: Array<ListItem> = []) {
     }

--- a/app/components/pipes/orderby-pipe/orderby.pipe.ts
+++ b/app/components/pipes/orderby-pipe/orderby.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Data } from './../../comparison/shared/index';
+import { isNullOrUndefined } from "util";
 
 @Pipe({
     name: 'orderBy',
@@ -47,8 +48,8 @@ export class OrderByPipe implements PipeTransform {
                     // b lacks the attribute => it is always below the others
                     return -1;
                 }
-                const pA = a[this.params.value[i]] ? a[this.params.value[i]] : a.properties[this.params.value[i]].plain;
-                const pB = b[this.params.value[i]] ? b[this.params.value[i]] : b.properties[this.params.value[i]].plain;
+                const pA = isNullOrUndefined(a[this.params.value[i]]) ? a.properties[this.params.value[i]].plain : a[this.params.value[i]];
+                const pB = isNullOrUndefined(b[this.params.value[i]]) ? b.properties[this.params.value[i]].plain : b[this.params.value[i]];
                 const comparison = !desc ? OrderByPipe._comparator(pA, pB) : -OrderByPipe._comparator(pA, pB);
                 if (comparison !== 0) {
                     return comparison;


### PR DESCRIPTION
Repo columns could no longer be sorted because the "plain" value of the property was not set correctly.

Fixes #114