### PR TITLE
Fix fkeys.json generation for Windows

### DIFF
--- a/citation/bibtex2json.js
+++ b/citation/bibtex2json.js
@@ -63,7 +63,7 @@ var extractFormatedKeys = function (filepath) {
     result = result.replace(/&#(\d+);/g, function (match, dec) {
         return String.fromCharCode(dec);
     });
-    result = result.replace(/&quot;/g, function (match, dec) {
+    result = result.replace(/&quot;|”|“/g, function (match, dec) {
         return '"';
     });
     result = result.replace(/<[^>]+>/g, function (match, dec) {


### PR DESCRIPTION
In Windows 10 the `keys.html` contains quotation marks ”“ instead of `&quot;`. Therefore the string replace does not work properly.