### PR TITLE
Add differentiation between URLs and non-URLs in titles

### DIFF
--- a/app/components/output/generic-table/generic-table.component.html
+++ b/app/components/output/generic-table/generic-table.component.html
@@ -18,7 +18,9 @@
     <template ngFor let-dat [ngForOf]="data | orderBy: [order,orderOption] | datafilter: [query, displayTemplate]">
         <tr *ngIf="shouldBeShown(dat)">
             <template ngFor let-column [ngForOf]="columns | tablefilter">
-                <td *ngIf="column.type?.tag==='url'"><a class="anchored" href="{{dat.getProperty(column.url).text}}" target="_blank">{{dat.getProperty(column.tag).text}}</a>
+                <td *ngIf="column.type?.tag==='url'">
+                    <a *ngIf="isUrl(dat.getProperty(column.url).text)" class="anchored" href="{{dat.getProperty(column.url).text}}" target="_blank">{{dat.getProperty(column.tag).text}}</a>
+                    <div *ngIf="!isUrl(dat.getProperty(column.url).text)" class="anchored">{{dat.getProperty(column.tag).text}}</div>
                 </td>
                 <td *ngIf="column.type?.tag==='text'">
                     <div [innerHtml]="dat.getProperty(column.tag).text|citation: [citationServ] | sanitizeHtml"></div>

--- a/app/components/output/generic-table/generic-table.component.ts
+++ b/app/components/output/generic-table/generic-table.component.ts
@@ -189,4 +189,11 @@ export class GenericTableComponent implements AfterViewChecked, OnChanges {
         }
         input.addToGui(value);
     }
+
+    public isUrl(text: string) {
+        if (text === null || text === undefined) {
+            return false;
+        }
+        return text.startsWith('http');
+    }
 }


### PR DESCRIPTION
When the title of an element in the comparison was without a URL, the resulting entry in the
table was still a link.
This is now fixed by checking if the provided link exists and a primitive check whether it is
a URL.

Example, Default 1 has no URL:
![image](https://user-images.githubusercontent.com/7841099/31659145-6d61b51a-b333-11e7-9d14-dd42dde224f5.png)
